### PR TITLE
Update default MySolutionStackName in EB template

### DIFF
--- a/samples/beanstalk/pipeline.yml
+++ b/samples/beanstalk/pipeline.yml
@@ -28,7 +28,7 @@ Parameters:
   MySolutionStackName:
     Description: Name of the current solution stack name. See https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html
     Type: String
-    Default: 64bit Amazon Linux 2017.09 v4.4.6 running Node.js
+    Default: 64bit Amazon Linux 2018.03 v4.5.4 running Node.js
     ConstraintDescription: Can contain only ASCII characters.
 Metadata:
   AWS::CloudFormation::Interface:


### PR DESCRIPTION
The old value seems to not be valid anymore (tested in us-east-1)

> No Solution Stack named '64bit Amazon Linux 2017.09 v4.4.6 running Node.js' found. (Service: AWSElasticBeanstalk; Status Code: 400; Error Code: InvalidParameterValue; Request ID: 1e599dfa-f888-4074-93ca-8b86921c1d74)