### PR TITLE
Include actual region from event for embedded link

### DIFF
--- a/samples/ec2/pipeline.yml
+++ b/samples/ec2/pipeline.yml
@@ -80,9 +80,10 @@ Resources:
             Ref: "MySNSTopic"
           Id: "PipelineNotificationTopic"
           InputTransformer:
-            InputTemplate: '"The Pipeline <pipeline> has failed. Go to https://console.aws.amazon.com/codepipeline/home?region=us-east-1#/view/<pipeline>" '
+            InputTemplate: '"The Pipeline <pipeline> has failed. Go to https://console.aws.amazon.com/codepipeline/home?region=<region>#/view/<pipeline>" '
             InputPathsMap:
               pipeline: "$.detail.pipeline" 
+              region: "$.region"
   ArtifactBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete


### PR DESCRIPTION
Glad to have come across this template. However, for the notification portion of a failed pipeline, the region was hardcoded to us-east-1. Considering the template has Ref calls to the AWS Region, I would assume this is not desired behavior. According to https://docs.amazonaws.cn/en_us/AmazonCloudWatch/latest/events/EventTypes.html#codepipeline_event_type we can grab the region for the pipeline and include it in the embedded url.